### PR TITLE
WARNING [5240755890] The class or interface 'sspmod_core_Auth_UserPassBase' is now using namespaces, please use 'SimpleSAML\Module\core\Auth\UserPassBase' instead.

### DIFF
--- a/lib/Auth/Source/SQL.php
+++ b/lib/Auth/Source/SQL.php
@@ -12,7 +12,7 @@
  * @package simpleSAMLphp
  * @version $Id$
  */
-class sspmod_sqlauthBcrypt_Auth_Source_SQL extends sspmod_core_Auth_UserPassBase {
+class sspmod_sqlauthbcrypt_Auth_Source_SQL extends SimpleSAML\Module\core\Auth\UserPassBase {
 
 
 	/**


### PR DESCRIPTION
With simplesamlphp 1.19.1