### PR TITLE
Update SQL.php

### DIFF
--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -168,7 +168,7 @@ class SQL extends \SimpleSAML\Module\core\Auth\UserPassBase
 		}
 
 		try {
-			$sth->execute(['username' => $username, 'password' => $password]);
+			$sth->execute(['username' => $username]);
 		} catch (PDOException $e) {
 			throw new Exception('sqlauthBcrypt:' . $this->authId .
 				': - Failed to execute query: ' . $e->getMessage());


### PR DESCRIPTION
Update for SimpleSaml V2.2.2. It seems that a plausibilty check is performed as the query-filter has only 1 parameter username.